### PR TITLE
Store transaction time series

### DIFF
--- a/helpers/redis.js
+++ b/helpers/redis.js
@@ -5,6 +5,8 @@ const { promisify } = require('util')
 const client = {
   get: promisify(syncClient.get).bind(syncClient),
   mget: promisify(syncClient.mget).bind(syncClient),
-  set: promisify(syncClient.set).bind(syncClient)
+  set: promisify(syncClient.set).bind(syncClient),
+  zadd: promisify(syncClient.zadd).bind(syncClient),
+  zrangebyscore: promisify(syncClient.zrangebyscore).bind(syncClient)
 }
 module.exports = client

--- a/routes/base_node.js
+++ b/routes/base_node.js
@@ -2,7 +2,7 @@ const express = require('express')
 const router = express.Router()
 const redis = require('../helpers/redis')
 const { redisPageRange } = require('../helpers/paging')
-const { blockHeight, headerHeight } = require('../helpers/sync')
+const { blockHeight, headerHeight, getTransactions } = require('../helpers/sync')
 
 router.get('/blocks', async (req, res, next) => {
   try {
@@ -37,4 +37,23 @@ router.get('/headers', async (req, res, next) => {
     return res.sendStatus(500).json(e)
   }
 })
+
+router.get('/transactions', async (req, res) => {
+  if (!req.query.from) {
+    return res.sendStatus(400)
+  }
+
+  const from = +req.query.from
+  if (isNaN(from)) {
+    return res.sendStatus(400)
+  }
+
+  try {
+    const transactions = await getTransactions(from)
+    return res.json({ transactions })
+  } catch (e) {
+    return res.sendStatus(500).json(e)
+  }
+})
+
 module.exports = router


### PR DESCRIPTION
The number of transactions for each block is equal to the number of kernels.

Transaction data is stored in a [Redis Sorted Set](https://redis.io/topics/data-types#sorted-sets) under the `transactions` key, with block timestamps as scores. Set members are stored in a custom format:

`{blockHeight}:{timestamp}:{transactions}`

The test network time series starts from April 26th, which is roughly a month's worth of data at this point, and the response time is always under 50ms on my machine. According to the current spec, the official block explorer client will request at most the last 7 days of transactions. Lookup times are basically `log(N)` for `N` blocks, so we should be OK on the performance side of things.

I think that grouping and aggregation by hours / days / etc. is best left for the client to decide.