### PR TITLE
Added single block lookup endpoint

### DIFF
--- a/helpers/redis.js
+++ b/helpers/redis.js
@@ -12,6 +12,9 @@ const client = {
   incrby: promisify(syncClient.incrby).bind(syncClient),
   mget: promisify(syncClient.mget).bind(syncClient),
   set: promisify(syncClient.set).bind(syncClient),
+  hset: promisify(syncClient.hset).bind(syncClient),
+  hget: promisify(syncClient.hget).bind(syncClient),
+  hmget: promisify(syncClient.hmget).bind(syncClient),
   zadd: promisify(syncClient.zadd).bind(syncClient),
   zrangebyscore: promisify(syncClient.zrangebyscore).bind(syncClient),
   zremrangebyscore: promisify(syncClient.zremrangebyscore).bind(syncClient),
@@ -26,6 +29,7 @@ const REDIS_STORE_KEYS = {
   DIFFICULTIES_BY_HEIGHT: 'difficulties_by_height',
   BLOCKS_BY_HEIGHT: 'blocks_by_height',
   BLOCKS_BY_TIME: 'blocks_by_time',
+  BLOCKS_BY_HASH: 'blocks_by_hash',
   CONSTANTS: 'constants'
 }
 module.exports = { client, REDIS_STORE_KEYS }

--- a/models/base_node.js
+++ b/models/base_node.js
@@ -74,8 +74,17 @@ const getBlockHeight = async () => {
   return +(await redis.get(REDIS_STORE_KEYS.BLOCK_CURRENT_HEIGHT) || 0)
 }
 
-const getBlocks = async (from, to) => {
-  return (await redis.zrangebyscore(REDIS_STORE_KEYS.BLOCKS_BY_HEIGHT, from, to)).map(JSON.parse)
+const getBlocksByHeight = async (from, to) => {
+  const blockHashes = await redis.zrangebyscore(REDIS_STORE_KEYS.BLOCKS_BY_HEIGHT, from, to)
+  return await getBlocksByHashes(blockHashes)
+}
+
+const getBlocksByHashes = async (hashes = []) => {
+  if (hashes.length > 0) {
+    const blocks = await redis.hmget(REDIS_STORE_KEYS.BLOCKS_BY_HASH, ...hashes.map(hash => hash))
+    return blocks.map(JSON.parse)
+  }
+  return []
 }
 
 const getConstants = async () => {
@@ -106,7 +115,8 @@ const getTotalTransactions = async () => {
 module.exports = {
   getBlockHeight,
   getChainMetadata,
-  getBlocks,
+  getBlocksByHeight,
+  getBlocksByHashes,
   getConstants,
   getTransactions,
   getChainRunningTime,

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const router = express.Router()
-const redis = require('../helpers/redis')
+const { client: redis } = require('../helpers/redis')
 const { simpleAuth } = require('../middleware/auth')
 const { baseNode } = require('../protos')
 const {


### PR DESCRIPTION
Blocks can be accessed at `http://localhost:4000/block/[blockHeight|blockHash]`
Moved the block data into a redis hash
Only store the hash in the zranges for height and time, then pull from
the hash for the data.
This is a redis data breaking change so you'll need to run
```
curl -X POST 'localhost:4000/admin/flush?token=admin' && curl -X POST 'localhost:4000/admin/sync?token=admin'
```
