### PR TITLE
Added override sync block height

### DIFF
--- a/helpers/sync.js
+++ b/helpers/sync.js
@@ -97,11 +97,11 @@ const syncBlocks = async (sockets, overrideBlockHeight) => {
   try {
     // If we override we are re-syncing from a certain point to keep up to date with the chain
     const useOverride = (overrideBlockHeight !== undefined)
-    let currentCacheBlockHeight = useOverride ? overrideBlockHeight : await getBlockHeight()
+    let currentCacheBlockHeight = useOverride ? +overrideBlockHeight : await getBlockHeight()
     const constants = await getConstants()
     // Get the tip
     const currentChainTip = await protos.baseNode.GetChainTip()
-    console.debug('Syncing Blocks - Cache Height:', currentCacheBlockHeight, 'Chain Height:', currentChainTip)
+    console.debug(useOverride ? `Overriding sync from height: ${overrideBlockHeight}` : '', 'Syncing Blocks - Cache Height:', currentCacheBlockHeight, 'Chain Height:', currentChainTip)
     let currentBlockHeight = currentCacheBlockHeight
     let broadcastBlock
     while (currentCacheBlockHeight < currentChainTip) {

--- a/helpers/sync.js
+++ b/helpers/sync.js
@@ -88,14 +88,16 @@ const syncDifficulties = async () => {
   }
 }
 
-const syncBlocks = async (sockets) => {
+const syncBlocks = async (sockets, overrideBlockHeight) => {
   if (LOCKS.blocks) {
     console.log('syncBlocks locked')
     return
   }
   LOCKS.blocks = true
   try {
-    let currentCacheBlockHeight = await getBlockHeight()
+    // If we override we are re-syncing from a certain point to keep up to date with the chain
+    const useOverride = (overrideBlockHeight !== undefined)
+    let currentCacheBlockHeight = useOverride ? overrideBlockHeight : await getBlockHeight()
     const constants = await getConstants()
     // Get the tip
     const currentChainTip = await protos.baseNode.GetChainTip()
@@ -108,24 +110,31 @@ const syncBlocks = async (sockets) => {
 
       console.debug('Fetching block heights', Math.min(...heights), ' - ', Math.max(...heights), ' / ', currentChainTip)
       const blocks = await protos.baseNode.GetBlocks(heights)
-      const { tmpCurrentBlockHeight, tmpBroadcastBlock } = await _processBlocks(blocks, currentBlockHeight, constants)
+      const { tmpCurrentBlockHeight, tmpBroadcastBlock } = await _processBlocks(blocks, currentBlockHeight, constants, useOverride)
       currentBlockHeight = tmpCurrentBlockHeight
       broadcastBlock = tmpBroadcastBlock
-      await redis.set(REDIS_STORE_KEYS.BLOCK_CURRENT_HEIGHT, currentBlockHeight)
+      if (!useOverride) {
+        // Only set our cache height for non re-sync operations
+        await redis.set(REDIS_STORE_KEYS.BLOCK_CURRENT_HEIGHT, currentBlockHeight)
+      }
+
       console.debug('Setting new block height', currentBlockHeight)
       // Broadcast the latest block to all the websocket clients
-      const now = (new Date()).getTime()
-      if (broadcastBlock && now > webSocketDebounce + WS_DEBOUNCE_TIMEOUT) {
-        webSocketDebounce = now
-        sockets.broadcast({
-          type: 'newBlock',
-          data: broadcastBlock
-        })
-        sockets.broadcast({
-          type: 'metadata',
-          data: await getChainMetadata()
-        })
+      if (!useOverride) {
+        const now = (new Date()).getTime()
+        if (broadcastBlock && now > webSocketDebounce + WS_DEBOUNCE_TIMEOUT) {
+          webSocketDebounce = now
+          sockets.broadcast({
+            type: 'newBlock',
+            data: broadcastBlock
+          })
+          sockets.broadcast({
+            type: 'metadata',
+            data: await getChainMetadata()
+          })
+        }
       }
+
       await sleep(1000)
       currentCacheBlockHeight = currentBlockHeight
     }
@@ -146,7 +155,7 @@ const syncBlocks = async (sockets) => {
  * @returns {Promise<{tmpCurrentBlockHeight: *, tmpBroadcastBlock: *}>}
  * @private
  */
-const _processBlocks = async (blocks, currentBlockHeight, constants) => {
+const _processBlocks = async (blocks, currentBlockHeight, constants, useOverride) => {
   blocks.sort((a, b) => +a.block.header.timestamp.seconds - +b.block.header.timestamp.seconds)
   let tmpBroadcastBlock
   for (const i in blocks) {
@@ -175,6 +184,10 @@ const _processBlocks = async (blocks, currentBlockHeight, constants) => {
 
     const blockDataString = JSON.stringify(blockData)
     await redis.hset(REDIS_STORE_KEYS.BLOCKS_BY_HASH, hash, blockDataString)
+    if (useOverride) {
+      await redis.zremrangebyscore(REDIS_STORE_KEYS.BLOCKS_BY_HEIGHT, blockHeight, blockHeight)
+      await redis.zremrangebyscore(REDIS_STORE_KEYS.BLOCKS_BY_TIME, milliseconds, milliseconds)
+    }
     await redis.zadd(REDIS_STORE_KEYS.BLOCKS_BY_HEIGHT, blockHeight, hash)
     await redis.zadd(REDIS_STORE_KEYS.BLOCKS_BY_TIME, milliseconds, hash)
     await setTransactionsCount(blockData)

--- a/models/base_node.js
+++ b/models/base_node.js
@@ -82,7 +82,7 @@ const getBlocksByHeight = async (from, to) => {
 const getBlocksByHashes = async (hashes = []) => {
   if (hashes.length > 0) {
     const blocks = await redis.hmget(REDIS_STORE_KEYS.BLOCKS_BY_HASH, ...hashes.map(hash => hash))
-    return blocks.map(JSON.parse)
+    return blocks.map(JSON.parse).filter(b => b !== null)
   }
   return []
 }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -25,12 +25,12 @@ router.post('/flush', async (req, res) => {
 })
 
 router.post('/sync', async (req, res) => {
-  const { type = 'all' } = req.query
+  const { type = 'all', overrideHeight } = req.query
   if (type === 'all' || type === 'constants') {
     await syncConstants()
   }
   if (type === 'all' || type === 'blocks') {
-    syncBlocks(req.app._sockets)
+    syncBlocks(req.app._sockets, overrideHeight)
   }
   if (type === 'all' || type === 'difficulties') {
     syncDifficulties()


### PR DESCRIPTION
### Description

Allow the admin endpoint to accept `overrideHeight` that will start the sync at a set height and fetch the latest data from the base node. It overrides the current data but doesn't trigger websocket updates. This is for more up to date confirmations on blocks / re-orgs etc.