### PR TITLE
Filter changed the return type of the block

### DIFF
--- a/routes/base_node.js
+++ b/routes/base_node.js
@@ -26,7 +26,7 @@ router.get('/block/:blockId', async (req, res) => {
   try {
     const { blockId } = req.params
     const block = (Number.isInteger(+blockId) ? await getBlocksByHeight(+blockId, +blockId) : await getBlocksByHashes([blockId])).pop()
-    if (block === null) {
+    if (!block) {
       return res.sendStatus(404)
     }
     return res.json(block)


### PR DESCRIPTION
The model is filtering out `null` values so can return an empty array. If you pop an empty array you get an undefined. Changed the block check to be falsey to catch any type of non object value.