### PR TITLE
Using a custom Dockerfile for health checks

### DIFF
--- a/basenode.Dockerfile
+++ b/basenode.Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/krakaw/tari_base_node:latest
+
+WORKDIR /root/.tari
+COPY ./scripts/docker-fix-config.sh /usr/bin
+COPY ./protos/base_node/base_node.proto /root/
+RUN curl -L -o /tmp/grpcurl.tgz 'https://github.com/fullstorydev/grpcurl/releases/download/v1.6.0/grpcurl_1.6.0_linux_x86_64.tar.gz' && \
+    tar -xzf /tmp/grpcurl.tgz -C /usr/bin && rm /tmp/grpcurl.tgz
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=35s --retries=3 CMD grpcurl -plaintext -import-path /root  -proto /root/base_node.proto localhost:18142 tari.base_node.BaseNode.GetVersion || exit 1
+CMD bash -c "/usr/bin/docker-fix-config.sh && /usr/bin/start.sh"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,11 +34,13 @@ services:
     ports:
       - "18142:18142"
     tty: true
+    restart: unless-stopped
   redis:
     image: "redis:alpine"
     volumes:
       - "$PWD/_data/redis:/data"
     command: "redis-server --appendonly yes"
+    restart: unless-stopped
     expose:
       - 6379
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: quay.io/krakaw/block-explorer-frontend:latest
     env_file: .env.docker.frontend
     volumes:
-    - frontend:/app/dist
+      - frontend:/app/dist
   api:
     image: quay.io/krakaw/blockchain-explorer-api:latest
     env_file: .env
@@ -23,19 +23,18 @@ services:
       timeout: 5s
       retries: 3
   tari:
-    image: quay.io/krakaw/tari_base_node:latest
+#    image: quay.io/krakaw/tari_base_node:latest
+    build:
+      context: .
+      dockerfile: basenode.Dockerfile
     volumes:
       - "$PWD/_data/tari:/root/.tari"
-      - "$PWD/scripts/docker-fix-config.sh:/usr/bin/docker-fix-config.sh"
     stdin_open: true
     expose:
       - 18142
     ports:
       - "18142:18142"
     tty: true
-    command:
-      - "/usr/bin/docker-fix-config.sh"
-      - "/usr/bin/start.sh"
   redis:
     image: "redis:alpine"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       timeout: 5s
       retries: 3
   tari:
-#    image: quay.io/krakaw/tari_base_node:latest
     build:
       context: .
       dockerfile: basenode.Dockerfile

--- a/scripts/docker-fix-config.sh
+++ b/scripts/docker-fix-config.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
+echo "Checking ~/.tari/config.toml for grpc_enabled and grpc_address"
 if [[ ! -f ~/.tari/config.toml ]]; then
+  echo "There is no config.toml - creating."
   tari_base_node --init --create-id
+  echo "Updating grpc_enabled = true"
   sed -i  's/grpc_enabled = false/grpc_enabled = true/' ~/.tari/config.toml
+  echo "Updating grpc_address = 0.0.0.0:18142"
   sed -i  's/grpc_address = "127.0.0.1:18142"/grpc_address = "0.0.0.0:18142"/' ~/.tari/config.toml
+else
+  echo "Config file already exists, exiting."
 fi
 


### PR DESCRIPTION
Building a new image from the tari_base_node image and adding in the custom startup scripts, grpcurl for querying the grpc service and the proto file. This lets us run a healthcheck and restart the base node automatically.