### PR TITLE
update proto remote url

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 API_PORT=4000
 GRPC_URL=tari:18142
 REDIS_URL=redis://redis:6379
-PROTO_REMOTE_URL=https://raw.githubusercontent.com/tari-project/tari/development/applications/tari_base_node/proto/base_node.proto
+PROTO_REMOTE_URL=https://raw.githubusercontent.com/tari-project/tari/development/applications/tari_app_grpc/proto/base_node.proto
 ADMIN_TOKEN=admin
 NO_CRON=
 BLOCK_TIME_SECONDS=120


### PR DESCRIPTION
looks like the proto file was moved to a different application in TBN some time ago - previous link is 404 